### PR TITLE
Add speech-level `@` tag parsing & styling

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -307,12 +307,55 @@ button#submit {
 }
 
 /* start kor speech level tags */
-span.formal-tag,
-span.polite-tag,
-span.impolite-tag,
-span.honorific-tag,
-span.plain-tag {
-  background-color: red;
+span.speech-level-tag {
+  border-radius: 0;
+  min-width: 150px;
+  background-color: rgba(255, 255, 255, 0.025);
+  font-size: 75%;
+  border: 0;
+  border-left: solid 2px rgba(255, 255, 255, 0.2);
+  border-right: solid 2px rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  padding: 0.1em 0.7em;
+  margin: 0;
+  margin-left: 0.25em;
+}
+/* honorific: purple, formal: blue, polite: pink, impolite: green , plain: yellow, i: green */
+span.speech-level-tag.formal-tag {
+  background-color: rgba(22, 158, 255, 0.1);
+  border-left: solid 2px rgba(22, 158, 255, 0.8);
+  border-right: solid 2px rgba(22, 158, 255, 0.8);
+  color: rgba(22, 158, 255, 1);
+}
+
+span.speech-level-tag.polite-tag {
+  background-color: rgba(255, 96, 189, 0.1);
+  border-left: solid 2px rgba(255, 96, 189, 0.8);
+  border-right: solid 2px rgba(255, 96, 189, 0.8);
+  color: rgba(255, 96, 189, 1);
+}
+
+span.speech-level-tag.impolite-tag,
+  span.speech-level-tag.i-tag {
+  background-color: rgba(24, 255, 0, 0.1);
+  border-left: solid 2px rgba(24, 255, 0, 0.8);
+  border-right: solid 2px rgba(24, 255, 0, 0.8);
+  color: rgba(24, 255, 0, 1);
+}
+
+span.speech-level-tag.honorific-tag {
+  background-color: rgba(145, 61, 252, 0.1);
+  border-left: solid 2px rgba(165, 94, 255, 0.8);
+  border-right: solid 2px rgba(165, 94, 255, 0.8);
+  color: rgba(165, 94, 255, 1);
+}
+
+span.speech-level-tag.plain-tag {
+  background-color: rgba(255, 253, 0, 0.1);
+  border-left: solid 2px rgba(255, 253, 0, 0.8);
+  border-right: solid 2px rgba(255, 253, 0, 0.8);
+  color: rgba(255, 253, 0, 1);
 }
 /* end kor speech level tags */
 

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -321,7 +321,7 @@ span.speech-level-tag {
   margin: 0;
   margin-left: 0.25em;
 }
-/* honorific: purple, formal: blue, polite: pink, impolite: green , plain: yellow, i: green */
+
 span.speech-level-tag.formal-tag {
   background-color: rgba(22, 158, 255, 0.1);
   border-left: solid 2px rgba(22, 158, 255, 0.8);

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -306,6 +306,16 @@ button#submit {
   right: 40px;
 }
 
+/* start kor speech level tags */
+span.formal-tag,
+span.polite-tag,
+span.impolite-tag,
+span.honorific-tag,
+span.plain-tag {
+  background-color: red;
+}
+/* end kor speech level tags */
+
 .tooltip-inner {
   border-radius: 0;
   background-color: rgba(0,0,0,0.8);

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -520,16 +520,23 @@ function display(isFlu) {
     var formatted = currentEntry.formatted
     if (formatted != "") {
         formattedHtml = generateFormattedHtml(formatted, english);
+        fancyTagsHtml = generateFancyTagsInHtml(formattedHtml);
+        console.log("BEFORE");
+        console.log(formattedHtml);
+        console.log("AFTER");
+        console.log(fancyTagsHtml);
+        
         if (isFlu) {
-            $('.flu-display-text').html(formattedHtml);
+            $('.flu-display-text').html(fancyTagsHtml);
         } else {
-            $('.display-text').html(formattedHtml);
+            $('.display-text').html(fancyTagsHtml);
         }
     } else {
+        fancyTagsHtml = generateFancyTagsInHtml(english);
         if (isFlu) {
-            $('.flu-display-text').html(english);
+            $('.flu-display-text').html(fancyTagsHtml);
         } else {
-            $('.display-text').html(english);
+            $('.display-text').html(fancyTagsHtml);
         }
     }
 }
@@ -571,6 +578,37 @@ function dimString(string) {
 
 function brightenString(string) {
     return string;
+}
+
+function generateFancyTagsInHtml(formattedHtml) {
+    // Generate map: tag x span
+    // > Exact strings the .replace needs
+    function generateMap(tagNames, prefix) {
+        var map = {};
+        for (var i=0; i<tagNames.length; i++) {
+            var tagName = tagNames[i];
+            var tag = prefix + tagName;
+            var className = tagName + "-tag";
+    
+            map[tag] = `<span class='${className}'>${tagName}</span>`;
+        }
+        return map;
+    }
+
+    var prefix = "@";
+    var tagNames = [ 
+        "formal",
+        "polite",
+        "impolite",
+        "honorific",
+        "plain"
+    ];
+
+    var stringReplaceMap = generateMap(tagNames, prefix);
+    var regex = new RegExp(`${prefix}\\S+\\b`, "gi");
+    var tryReplace = formattedHtml.replace(regex, matched => stringReplaceMap[matched]);
+    
+    return tryReplace ? tryReplace : formattedHtml;
 }
 
 function unboldString(string) {

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -577,13 +577,10 @@ function brightenString(string) {
 }
 
 function generateFancyTagsInHtml(formattedHtml) {
-    console.log("IN FUNCTION...");
     var prefix = "@";
     var regex = new RegExp(`${prefix}\\S+\\b`, "gi");
     // var tryReplace = formattedHtml.replace(regex, matched => stringReplaceMap[matched]);
     var allTagsFound = formattedHtml.match(regex);
-    console.log("ALL TAGS");
-    console.log(allTagsFound);
     if (!allTagsFound || allTagsFound.length === 0) {
         return formattedHtml;
     }
@@ -622,14 +619,9 @@ function generateFancyTagsInHtml(formattedHtml) {
             continue;
         }
 
-        console.log("BEFORE");
-        console.log(fancyTagsHtml);
         fancyTagsHtml = fancyTagsHtml.replace(currentTag, stringReplaceMap[currentTag]);
-        console.log("AFTER");
-        console.log(fancyTagsHtml);
     }
-    console.log("FINALLY");
-    console.log(fancyTagsHtml);
+
     return fancyTagsHtml;
 }
 

--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -521,11 +521,7 @@ function display(isFlu) {
     if (formatted != "") {
         formattedHtml = generateFormattedHtml(formatted, english);
         fancyTagsHtml = generateFancyTagsInHtml(formattedHtml);
-        console.log("BEFORE");
-        console.log(formattedHtml);
-        console.log("AFTER");
-        console.log(fancyTagsHtml);
-        
+
         if (isFlu) {
             $('.flu-display-text').html(fancyTagsHtml);
         } else {
@@ -581,6 +577,17 @@ function brightenString(string) {
 }
 
 function generateFancyTagsInHtml(formattedHtml) {
+    console.log("IN FUNCTION...");
+    var prefix = "@";
+    var regex = new RegExp(`${prefix}\\S+\\b`, "gi");
+    // var tryReplace = formattedHtml.replace(regex, matched => stringReplaceMap[matched]);
+    var allTagsFound = formattedHtml.match(regex);
+    console.log("ALL TAGS");
+    console.log(allTagsFound);
+    if (!allTagsFound || allTagsFound.length === 0) {
+        return formattedHtml;
+    }
+
     // Generate map: tag x span
     // > Exact strings the .replace needs
     function generateMap(tagNames, prefix) {
@@ -588,27 +595,42 @@ function generateFancyTagsInHtml(formattedHtml) {
         for (var i=0; i<tagNames.length; i++) {
             var tagName = tagNames[i];
             var tag = prefix + tagName;
-            var className = tagName + "-tag";
+            var className = tagName + "-tag speech-level-tag";
     
             map[tag] = `<span class='${className}'>${tagName}</span>`;
         }
         return map;
     }
 
-    var prefix = "@";
     var tagNames = [ 
         "formal",
         "polite",
         "impolite",
         "honorific",
-        "plain"
+        "plain",
+        "i"
     ];
 
     var stringReplaceMap = generateMap(tagNames, prefix);
-    var regex = new RegExp(`${prefix}\\S+\\b`, "gi");
-    var tryReplace = formattedHtml.replace(regex, matched => stringReplaceMap[matched]);
-    
-    return tryReplace ? tryReplace : formattedHtml;
+
+    // Replace
+    var fancyTagsHtml = formattedHtml;
+    for (var i=0; i<allTagsFound.length; i++) {
+        var currentTag = allTagsFound[i];
+
+        if (!stringReplaceMap[currentTag]) {
+            continue;
+        }
+
+        console.log("BEFORE");
+        console.log(fancyTagsHtml);
+        fancyTagsHtml = fancyTagsHtml.replace(currentTag, stringReplaceMap[currentTag]);
+        console.log("AFTER");
+        console.log(fancyTagsHtml);
+    }
+    console.log("FINALLY");
+    console.log(fancyTagsHtml);
+    return fancyTagsHtml;
 }
 
 function unboldString(string) {

--- a/assets/txt/flu207.txt
+++ b/assets/txt/flu207.txt
@@ -19,7 +19,7 @@
     E: to me, from me
 
     O: 너한테 할 말이 있어.
-    E: I have something to say to you. @informal 🤔
+    E: I have something to say to you. @impolite 🤔
 
     # 차이다 = to be dumped
     O: 남자친구한테 차였어요.

--- a/assets/txt/flu209.txt
+++ b/assets/txt/flu209.txt
@@ -78,4 +78,4 @@
 
     # 사탕 = candy
     O: 사탕 몇 개 먹을래?
-    E: How many candies do you want[f] to eat? @informal 🤔
+    E: How many candies do you want[f] to eat? @impolite 🤔

--- a/assets/txt/flu316.txt
+++ b/assets/txt/flu316.txt
@@ -19,7 +19,7 @@
     E: Let’s start. @impolite
 
     O: 시작할래요?
-    E: Shall we start? (lit. Do you want to start?) @polite @casual
+    E: Shall we start? (lit. Do you want to start?) @polite
 
     O: 시작하실래요?
     E: Shall we start? (lit. Do you want to start?) @polite @honorific

--- a/assets/txt/kor10.txt
+++ b/assets/txt/kor10.txt
@@ -10,8 +10,8 @@
     F: _This woman_ hates us. @polite
 
     O: 나는 차를 싫어합니다.
-    E: I hate tea. @formal,i
-    F: _I_ hate tea. @formal,i
+    E: I hate tea. @formal @i
+    F: _I_ hate tea. @formal @i
 
     O: 저는 운동을 좋아합니다.
     E: I like exercise. @formal
@@ -34,16 +34,16 @@
     F: _We_ love the sea. @formal
 
     O: 나는 개를 싫어하지 않아요.
-    E: I do not[l] hate dogs. @polite,i
-    F: _I_ do not[l] hate dogs. @polite,i
+    E: I do not[l] hate dogs. @polite @i
+    F: _I_ do not[l] hate dogs. @polite @i
 
     O: 저는 이 가방을 더 좋아합니다.
     E: I like this bag better. @formal
     F: _I_ like this bag better. @formal
 
     O: 나는 극장에서 영화를 봅니다.
-    E: I watch a movie at the theatre. @formal,i
-    F: _I_ watch a movie at the theatre. @formal,i
+    E: I watch a movie at the theatre. @formal @i
+    F: _I_ watch a movie at the theatre. @formal @i
 
     O: 우리는 개를 좋아합니다.
     E: We like dogs. @formal
@@ -58,8 +58,8 @@
     F: _We_ love Duolingo! @polite
 
     O: 나는 그것을 좋아합니다.
-    E: I like that. @formal,i
-    F: _I_ like that. @formal,i
+    E: I like that. @formal @i
+    F: _I_ like that. @formal @i
 
     O: 저는 그 남자를 미워합니다.
     E: I hate that man. @formal
@@ -75,32 +75,32 @@
 
 > Two
     O: 나는 그 학생을 믿습니다.
-    E: I believe that student. @formal,i
-    F: _I_ believe that student. @formal,i
+    E: I believe that student. @formal @i
+    F: _I_ believe that student. @formal @i
 
     O: 너와 나
     E: You and me @i
 
     O: 나를 놀리지 마십시오.
-    E: Please don't tease me. @formal,i
+    E: Please don't tease me. @formal @i
 
     O: 내 친구는 나를 너무 많이 속입니다.
-    E: My[s] friend deceives me too much. @formal,i
-    F: _My[s] friend_ deceives me too much. @formal,i
+    E: My[s] friend deceives me too much. @formal @i
+    F: _My[s] friend_ deceives me too much. @formal @i
 
     # It means "you guys" (너희). It like makes a plural "you".
     O: 너희와 나
     E: You[p] and me @i
 
     O: 나를 믿으십시오.
-    E: Please believe me. @formal,i
+    E: Please believe me. @formal @i
 
     O: 사람들이 우리를 놀려요.
     E: People make fun of us. @polite
     F: People _make fun of us_. @polite
 
     O: 나를 속이지 마십시오.
-    E: Please don't deceive me. @formal,i
+    E: Please don't deceive me. @formal @i
 
     O: 우리는 사람들을 놀립니다.
     E: We make fun of people. @formal
@@ -128,16 +128,16 @@
     # 나 자신을 means "I oneself/myself"
     # I don't think the meaning changes much.
     O: 나는 내 자신을 압니다.
-    E: I know myself[m]. @formal,i
-    F: _I_ know myself[m]. @formal,i
+    E: I know myself[m]. @formal @i
+    F: _I_ know myself[m]. @formal @i
 
     O: 나는 혼자 요리합니다.
-    E: I cook by myself. @formal,i
-    F: _I_ cook by myself. @formal,i
+    E: I cook by myself. @formal @i
+    F: _I_ cook by myself. @formal @i
 
     O: 너희가 서로 싫어합니다.
-    E: You hate each other. @formal,i
-    F: You _hate each other_. @formal,i
+    E: You hate each other. @formal @i
+    F: You _hate each other_. @formal @i
     
     O: 동물은 자기의 음식을 먹어요.
     E: The animal eats its own food. @polite
@@ -159,12 +159,12 @@
     E: Affirmative. @formal
 
     O: 나는 나 자신을 사랑합니다.
-    E: I love myself. @formal,i
-    F: _I_ love myself. @formal,i
+    E: I love myself. @formal @i
+    F: _I_ love myself. @formal @i
 
     O: 나는 그녀를 사랑해요.
-    E: I love her. @polite,i
-    F: _I_ love her. @polite,i
+    E: I love her. @polite @i
+    F: _I_ love her. @polite @i
 
     O: 혼자 공부하지 마십시오.
     E: Do not study alone. @formal
@@ -177,6 +177,6 @@
     F: _They_ know each other. @formal
 
     O: 나는 나 자신을 놀려요.
-    E: I make fun of myself. @polite,i
-    F: _I_ make fun of myself. @polite,i
+    E: I make fun of myself. @polite @i
+    F: _I_ make fun of myself. @polite @i
 

--- a/assets/txt/kor12.txt
+++ b/assets/txt/kor12.txt
@@ -247,8 +247,8 @@
     F: The sleeping girl _eats gimbap_. @polite
 
     O: 나는 웃는 친구를 좋아합니다.
-    E: I like friends who laugh. @formal,i
-    F: _I_ like friends who laugh. @formal,i
+    E: I like friends who laugh. @formal @i
+    F: _I_ like friends who laugh. @formal @i
 
     # The road home
     O: 집으로 가는 길
@@ -266,8 +266,8 @@
     F: The road to school _is long_. @polite
 
     O: 책을 읽는 학생이 내 친구입니다.
-    E: The student reading a book is my friend. @formal,i
-    F: The student reading a book _is my friend_. @formal,i
+    E: The student reading a book is my friend. @formal @i
+    F: The student reading a book _is my friend_. @formal @i
 
     O: 달리는 고양이가 안 빠릅니다.
     E: The running cat is not fast. @formal
@@ -297,8 +297,8 @@
     E: Flying dog
 
     O: 나는 우는 아기를 싫어합니다.
-    E: I hate crying babies. @formal,i
-    F: _I_ hate crying babies. @formal,i
+    E: I hate crying babies. @formal @i
+    F: _I_ hate crying babies. @formal @i
 
     O: 춤을 추는 아기
     E: A dancing baby
@@ -328,5 +328,5 @@
 
     # I, who is flying, am a man.
     O: 나는 나는 남자입니다.
-    E: I am a flying man. @formal,i
-    F: _I_ am a flying man. @formal,i
+    E: I am a flying man. @formal @i
+    F: _I_ am a flying man. @formal @i

--- a/assets/txt/kor13.txt
+++ b/assets/txt/kor13.txt
@@ -74,7 +74,7 @@
     F: But[s] _that_ is too expensive. @polite
 
     O: 나도 만진다.
-    E: I touch it too. @plain, i
+    E: I touch it too. @plain @i
 
     O: 하지만 저 사람은 남자가 아닙니다.
     E: But[hs] that person over there is not a man. @formal
@@ -116,8 +116,8 @@
     F: _This car_ is small but[s] expensive. @formal
 
     O: 나는 그녀를 사랑해요. 그런데 그녀는 나를 싫어해요.
-    E: I love her. But[s] _she_ hates me. @polite, i
-    F: _I_ love her. But[s] _she_ hates me. @polite, i
+    E: I love her. But[s] _she_ hates me. @polite @i
+    F: _I_ love her. But[s] _she_ hates me. @polite @i
 
     O: 고양이가 음식을 싫어하지만 먹어요.
     E: The cat hates food but[h] it eats it. @polite

--- a/assets/txt/kor144.txt
+++ b/assets/txt/kor144.txt
@@ -42,8 +42,8 @@
     F: The whale puts on a tie. @polite
 
     O: 나는 장갑을 끼고 학교에 갑니다.
-    E: I go to school wearing gloves. @formal,i
-    F: I go to school wearing gloves. @formal,i
+    E: I go to school wearing gloves. @formal @i
+    F: I go to school wearing gloves. @formal @i
 
     O: 남자가 넥타이를 못 맵니다.
     E: The man cannot tie a tie. @formal

--- a/assets/txt/kor145.txt
+++ b/assets/txt/kor145.txt
@@ -10,8 +10,8 @@
     E: Take off your belt. @polite
 
     O: 나는 매일 옷을 갈아입어요.
-    E: I change my clothes every day. @polite,i
-    F: _I_ change my clothes every day. @polite,i
+    E: I change my clothes every day. @polite @i
+    F: _I_ change my clothes every day. @polite @i
 
     O: 분홍 선글라스를 쓰세요.
     E: Wear pink sunglasses. @polite

--- a/assets/txt/kor16.txt
+++ b/assets/txt/kor16.txt
@@ -86,8 +86,8 @@
 
 > Three
     O: 나는 친구 마흔 명이 있어요.
-    E: I have forty friends. @polite,i
-    F: _I_ have forty friends. @polite,i
+    E: I have forty friends. @polite @i
+    F: _I_ have forty friends. @polite @i
 
     O: 연필 한 자루는 얼마입니까?
     E: How much is one pencil? @formal

--- a/assets/txt/kor19.txt
+++ b/assets/txt/kor19.txt
@@ -110,8 +110,8 @@
     F: _Where is_ the monster? @formal
 
     O: 나는 숲 속의 호랑이를 무서워해요.
-    E: I'm afraid of the tiger in the forest. @polite @i
-    F: _I_'m afraid of the tiger in the forest. @polite @i
+    E: I'm afraid of the tiger in the forest. @polite,i
+    F: _I_'m afraid of the tiger in the forest. @polite,i
 
     O: 저는 한국에 가고 싶어요.
     E: I want to go to Korea. @polite
@@ -162,8 +162,8 @@
     # 알다 and 모르다 are often conjugated to 알겠다 or 모르겠다.
     # Although they are conjugated to the future tense, those two words are typically used to express _ in the present tense.
     O: 나는 돌아오겠다.
-    E: I'll be back. @plain @i
-    F: _I_'ll be back. @plain @i
+    E: I'll be back. @plain,i
+    F: _I_'ll be back. @plain,i
 
     O: 뱀이 내려와요.
     E: The snake comes down. @polite

--- a/assets/txt/kor19.txt
+++ b/assets/txt/kor19.txt
@@ -110,8 +110,8 @@
     F: _Where is_ the monster? @formal
 
     O: 나는 숲 속의 호랑이를 무서워해요.
-    E: I'm afraid of the tiger in the forest. @polite,i
-    F: _I_'m afraid of the tiger in the forest. @polite,i
+    E: I'm afraid of the tiger in the forest. @polite @i
+    F: _I_'m afraid of the tiger in the forest. @polite @i
 
     O: 저는 한국에 가고 싶어요.
     E: I want to go to Korea. @polite
@@ -162,8 +162,8 @@
     # 알다 and 모르다 are often conjugated to 알겠다 or 모르겠다.
     # Although they are conjugated to the future tense, those two words are typically used to express _ in the present tense.
     O: 나는 돌아오겠다.
-    E: I'll be back. @plain,i
-    F: _I_'ll be back. @plain,i
+    E: I'll be back. @plain @i
+    F: _I_'ll be back. @plain @i
 
     O: 뱀이 내려와요.
     E: The snake comes down. @polite


### PR DESCRIPTION
Instead of a plaintext speech-level tag e.g. `@formal`, they're now parsed and should turn into styled `<span>` labels.

Also, clean up:
* Inconsistent naming of `@` tags
* No longer concat `,` for pronoun tags. Pronoun tags should now be its own separate `@` tag.

#### Before
<img width="125" alt="Screen Shot 2021-07-09 at 12 15 26 am" src="https://user-images.githubusercontent.com/5599306/124937534-d1faac00-e04a-11eb-8654-3fa0c69bbf9b.png">

#### After
<img width="154" alt="Screen Shot 2021-07-09 at 12 13 47 am" src="https://user-images.githubusercontent.com/5599306/124937412-b8f1fb00-e04a-11eb-98a4-a8963320f048.png">
<img width="89" alt="Screen Shot 2021-07-09 at 12 14 08 am" src="https://user-images.githubusercontent.com/5599306/124937418-ba232800-e04a-11eb-9ce2-6189e5b82a40.png">
